### PR TITLE
Adiciona testes para o comando pp.abort()

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	
 	api 'br.com.stone.posandroid:hal-api:1.0.1'
 	// TODO change to implementation
-	implementation 'br.com.stone.posandroid:hal-mock:1.0.1'
+	implementation 'br.com.stone.posandroid:hal-mock:1.2.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/app/src/androidTest/java/br/com/stone/posandroid/hal/demo/bc/ControlCommandsTest.kt
+++ b/app/src/androidTest/java/br/com/stone/posandroid/hal/demo/bc/ControlCommandsTest.kt
@@ -6,11 +6,18 @@ import br.com.stone.posandroid.hal.api.Properties.KEY_CONTEXT
 import br.com.stone.posandroid.hal.api.Properties.RESULTS_FILE_KEY
 import br.com.stone.posandroid.hal.api.Properties.TARGET_RESULT_KEY
 import br.com.stone.posandroid.hal.api.bc.Pinpad
+import br.com.stone.posandroid.hal.api.bc.PinpadCallbacks
+import br.com.stone.posandroid.hal.api.bc.PinpadResult
+import br.com.stone.posandroid.hal.api.bc.PinpadResultCallback
 import br.com.stone.posandroid.hal.api.bc.constants.ResultCode.Companion.PP_ALREADYOPEN
 import br.com.stone.posandroid.hal.api.bc.constants.ResultCode.Companion.PP_NOTOPEN
 import br.com.stone.posandroid.hal.api.bc.constants.ResultCode.Companion.PP_OK
 import br.com.stone.posandroid.hal.demo.HALConfig.deviceProvider
+import br.com.stone.posandroid.hal.demo.bc.base.AutoLoadTableTest.Companion.TABLE_STUB_TIMESTAMP
+import br.com.stone.posandroid.hal.demo.util.blockingAssertions
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -22,16 +29,18 @@ class ControlCommandsTest {
 
     private val stubResultsFolder = "control-command-test"
     private lateinit var pinpad: Pinpad
+    private lateinit var pinpadCallbacks: PinpadCallbacks
     private val context by lazy { InstrumentationRegistry.getInstrumentation().targetContext }
 
     @Before
     fun setup() {
+        pinpadCallbacks = mockk(relaxed = true)
         pinpad = deviceProvider.getPinpad(
             mutableMapOf(
                 KEY_CONTEXT to context
             ),
             mutableMapOf(TARGET_RESULT_KEY to RESULTS_FILE_KEY),
-            mockk()
+            pinpadCallbacks
         )
     }
 
@@ -71,5 +80,39 @@ class ControlCommandsTest {
             "$stubResultsFolder/validate_not_open.json"
 
         assertEquals(PP_NOTOPEN, pinpad.close())
+    }
+
+    @Test
+    fun validateAbortCommand() {
+        val instrumentedTestThread = Thread.currentThread()
+
+        pinpad.runtimeProperties[RESULTS_FILE_KEY] =
+            "$stubResultsFolder/validate_abort_command.json"
+
+        every { pinpadCallbacks.onAbort() } answers { instrumentedTestThread.interrupt() }
+
+        val pinpadResultAssertions = { _: PinpadResult -> }
+
+        val pinpadCommandsAssertions = { resultCallback: PinpadResultCallback ->
+
+            assertEquals(
+                PP_OK,
+                pinpad.getCard(
+                    "0099000000023850020904164230${TABLE_STUB_TIMESTAMP}000",
+                    resultCallback
+                )
+            )
+
+            pinpad.abort()
+
+            verify(exactly = 0) { resultCallback.onPinpadResult(any()) }
+        }
+
+        blockingAssertions(
+            pinpadResultAssertions,
+            pinpadCommandsAssertions
+        )
+
+        verify(exactly = 1) { pinpadCallbacks.onAbort() }
     }
 }

--- a/app/src/androidTest/java/br/com/stone/posandroid/hal/demo/util/TestUtils.kt
+++ b/app/src/androidTest/java/br/com/stone/posandroid/hal/demo/util/TestUtils.kt
@@ -37,7 +37,10 @@ fun blockingAssertions(
 
     pinpadCommandsAssertions(resultCallback)
 
-    semaphore.acquire()
+    try {
+        semaphore.acquire()
+    } catch (_: InterruptedException) {
+    }
 }
 
 /**

--- a/app/src/androidTest/resources/control-command-test/validate_abort_command.json
+++ b/app/src/androidTest/resources/control-command-test/validate_abort_command.json
@@ -1,0 +1,28 @@
+[
+  {
+    "pinpadResult": {
+      "command": "GCR",
+      "resultCode": 0
+    },
+    "asyncEvents": [
+      {
+        "time": 100,
+        "id": 2,
+        "params": ""
+      },
+      {
+        "time": 2000,
+        "id": 1,
+        "params": ""
+      }
+    ],
+    "asyncResult": {
+      "time": 1000,
+      "pinpadResult": {
+        "command": "GCR",
+        "resultCode": 0,
+        "output": "03001010500                                                                            29376436871651006=0305000523966        000                                                                                                        15376436871651006    01AMEX GREEN      246SERGIO SANTOS             05013100                   00000000076000"
+      }
+    }
+  }
+]


### PR DESCRIPTION
Also:
- Incrementa versão do `hal-mock` para permitir a execução de `pp.abort()` na implementação _default_.

### Azure Boards
- Fixes AB#97102
- Fixes AB#98419