### PR TITLE
Configurações de Assinatura da Gertec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /captures
 .externalNativeBuild
 local.properties
+/*/*-keystore.properties
+*.jks

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply from: '../gertec/gertec-signing-config.gradle'
 
 android {
 

--- a/gertec/gertec-signing-config.gradle
+++ b/gertec/gertec-signing-config.gradle
@@ -1,0 +1,24 @@
+
+def keystorePropertiesFile = rootProject.file("gertec/gertec-keystore.properties")
+def keystoreProperties = new Properties()
+keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+
+android {
+
+    signingConfigs {
+        gertec {
+            storeFile file("../gertec/${keystoreProperties['storeFile']}")
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storePassword keystoreProperties['storePassword']
+        }
+    }
+
+    buildTypes {
+        gertec {
+            initWith debug
+            signingConfig signingConfigs.gertec
+            matchingFallbacks = ['debug']
+        }
+    }
+}


### PR DESCRIPTION
Adiciona um buildType 'gertec' para assinar e debugar apps para rodarem nos terminais GPOS
É necessário add o gertec-keystore.jks e o gertec-keystore.properties na pasta 'gertec' na raiz do projeto para que seja possível compilar o buildType