### PR TITLE
Updating hal to 1.4.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,8 +32,8 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinx}"
-    api 'br.com.stone.posandroid:hal-api:1.2.1'
-    implementation 'br.com.stone.posandroid:hal-mock:1.2.1'
+    api 'br.com.stone.posandroid:hal-api:1.4.0'
+    implementation 'br.com.stone.posandroid:hal-mock:1.4.0'
 
 
     implementation 'br.com.stone:hal-pin-layout:2.10.0'

--- a/app/src/androidTest/resources/settings/settings-test/settings-deviceinfo.json
+++ b/app/src/androidTest/resources/settings/settings-test/settings-deviceinfo.json
@@ -4,6 +4,7 @@
     "isPosAndroid": true,
     "manufacturerName": "Stone",
     "fullDeviceName": "Stone Mock Device",
+    "modelName": "Stone Mock Device",
     "firmwareVersion": "1.0.0"
   }
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,12 @@ buildscript {
                 junit                : "4.12",
                 test_runner          : "1.0.2"
         ]
+        localProp = new Properties()
+        fileName = 'local.properties'
+        if (project.rootProject.file(fileName).exists()) {
+            localProp.load(new FileInputStream(rootProject.file(fileName)))
+        }
+        packageCloudReadToken = System.env.PACKAGECLOUD_TOKEN != null ? System.env.PACKAGECLOUD_READ_TOKEN  : localProp["packageCloudReadToken"] ?: ""
     }
 
     repositories {
@@ -39,6 +45,7 @@ allprojects {
         maven { url "https://packagecloud.io/stone/pos-android-hal/maven2" }
         maven { url "https://packagecloud.io/stone/pos-android-hal-internal/maven2" }
         maven { url "https://packagecloud.io/stone/sdk-android/maven2" }
+        maven { url "https://packagecloud.io/priv/${packageCloudReadToken}/stone/pos-android/maven2" }
     }
     group = "br.com.stone.posandroid"
 }


### PR DESCRIPTION
Atualiza a versão da hal para [1.4.0](https://github.com/stone-payments/pos-android-hal/releases/tag/1.4.0)
